### PR TITLE
Quickfix for navbar styling implementation

### DIFF
--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="/css/style.css" />
   </head>
   <body class="d-flex flex-column" style="min-height: 100%; background: #AFE1AF;">
-    <header class="container sticky-top">
-      <nav class="navbar navbar-expand-lg" style="background: #AFE1AF">
+    <header class="sticky-top">
+      <nav class="container navbar navbar-expand-lg" style="background: #AFE1AF">
         <div class="container-fluid">
           <a class="navbar-brand" href="/feed">
             <img alt="Tribal Logo" src="/imgs/tribalLogo.png" width="180" height="50">


### PR DESCRIPTION
Navbar has a bug where navigation width didn't cover the fixed length of the top of the viewport, leading to styling issues, specifically for mobile viewports.